### PR TITLE
Cambia identificadores para Disqus

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -95,8 +95,8 @@ into the {body} of the default.hbs template -->
                     <div id="disqus_thread"></div>
                     <script>
                         var disqus_config = function () {
-                            this.page.url = '{{ site.url }}{{ site.baseurl }}';
-                            this.page.identifier = '{{ site.title }}';
+                            this.page.url = '{{ site.url }}{{ site.baseurl }}{{ page.url | remove_first: '/' }}';
+                            this.page.identifier = '{% if title %}{{ title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}';
                         };
                         (function() {
                             var d = document, s = d.createElement('script');


### PR DESCRIPTION
Los comentarios se repiten entre posts, esto se debe a que los identificadores no estan siendo usados correctamente.